### PR TITLE
feat: ScreenRelayバージョンを0.1.1に更新

### DIFF
--- a/bucket/ScreenRelay.json
+++ b/bucket/ScreenRelay.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Capture all monitors on Windows via DXGI Desktop Duplication, encode each to H.264 (NVENC → h264_mf → libx264 fallback) with FFmpeg, and stream them as separate RTSP feeds (e.g., to MediaMTX).",
     "homepage": "https://github.com/tomacheese/ScreenRelay",
     "license": "MIT",
-    "url": "https://github.com/tomacheese/ScreenRelay/releases/download/v0.1.0/screen-relay-v0.1.0-win64.zip",
-    "hash": "47e94439a4f2eb0f0d2b7c2cc807dec02cd0a3d67fe76a52f5fdacc5643d6a00",
+    "url": "https://github.com/tomacheese/ScreenRelay/releases/download/v0.1.1/screen-relay-v0.1.1-win64.zip",
+    "hash": "13b40b4ce991ce3e83ce96e79602fb5c5aeac9f606c2bbd8d8dbee47a1137511",
     "shortcuts": [
         [
             "screen-relay.exe",


### PR DESCRIPTION
- URLとハッシュを新しいリリースに合わせて更新しました。