### PR TITLE
fix: Excavator を deploy key による master 直接 push に変更

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -1,7 +1,8 @@
 name: Excavator
 
-# ScoopInstaller/GithubActions@main は -Push モード固定のため、
-# ブランチ保護ルール (PR 必須) に対応するためカスタムステップで -Request モードを使用する
+# ScoopInstaller/GithubActions@main は -Push モード固定で、かつ auto-pr.ps1 の
+# -Request モードに既知のバグ (クォート漏れ) があるため、独自実装に置き換える
+# 参考: https://github.com/ScoopInstaller/Scoop/blob/master/bin/auto-pr.ps1#L134
 
 on:
   workflow_dispatch:
@@ -30,9 +31,6 @@ jobs:
           Invoke-WebRequest 'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' -UseBasicParsing -OutFile $installer
           & $installer
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:USERPROFILE 'scoop\shims')
-      - name: Install hub
-        shell: pwsh
-        run: scoop install hub
       - name: Configure git
         shell: pwsh
         env:
@@ -40,18 +38,73 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          $remUrl = "https://$($env:GITHUB_ACTOR):$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
-          git remote set-url --push origin $remUrl
-          git remote add upstream (git remote get-url origin)
+          git remote set-url --push origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
       - name: Excavate
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HUB_VERBOSE: "1"
+          SCOOP_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          $ErrorActionPreference = 'Continue'
+          $originBranch = 'master'
           $scoopHome = scoop prefix scoop
-          & (Join-Path $scoopHome 'bin\auto-pr.ps1') `
-            -Upstream "$($env:GITHUB_REPOSITORY):master" `
-            -Dir (Join-Path $env:GITHUB_WORKSPACE 'bucket') `
-            -Request `
-            -SkipUpdated
+          $bucketDir = Join-Path $env:GITHUB_WORKSPACE 'bucket'
+
+          # 全マニフェストのバージョンチェックと更新
+          & (Join-Path $scoopHome 'bin\checkver.ps1') -Dir $bucketDir -Update -SkipUpdated
+
+          # 変更されたマニフェストを取得
+          $changedFiles = git diff --name-only | Where-Object { $_ -like 'bucket/*.json' }
+
+          if (-not $changedFiles) {
+            Write-Host 'No updates found.'
+            exit 0
+          }
+
+          foreach ($file in $changedFiles) {
+            $app = [System.IO.Path]::GetFileNameWithoutExtension($file)
+            $json = Get-Content $file -Raw | ConvertFrom-Json
+            $version = $json.version
+            $branch = "manifest/$app-$version"
+
+            # リモートブランチが既に存在する場合はスキップ
+            $remoteExists = git ls-remote --heads origin $branch
+            if ($remoteExists) {
+              Write-Host "Branch $branch already exists, skipping $app..."
+              git checkout -- $file
+              continue
+            }
+
+            Write-Host "Creating PR for $app $version..."
+
+            git checkout -b $branch
+            git add $file
+            git commit -m "${app}: Update to version ${version}"
+            git push origin $branch
+
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "Push failed for $branch, skipping..."
+              git checkout $originBranch
+              continue
+            }
+
+            $homepage = $json.homepage
+            $prBody = @"
+${app}: Update to version ${version}
+
+Hello lovely humans,
+a new version of [${app}](${homepage}) is available.
+
+| State       | Update |
+| :---------- | :----- |
+| New version | ${version} |
+"@
+
+            gh pr create `
+              --title "${app}: Update to version ${version}" `
+              --body $prBody `
+              --base $originBranch `
+              --head $branch
+
+            git checkout $originBranch
+          }

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -1,9 +1,5 @@
 name: Excavator
 
-# ScoopInstaller/GithubActions@main は -Push モード固定で、かつ auto-pr.ps1 の
-# -Request モードに既知のバグ (クォート漏れ) があるため、独自実装に置き換える
-# 参考: https://github.com/ScoopInstaller/Scoop/blob/master/bin/auto-pr.ps1#L134
-
 on:
   workflow_dispatch:
   schedule:
@@ -12,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   excavate:
@@ -33,20 +28,26 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:USERPROFILE 'scoop\shims')
       - name: Configure git
         shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git remote set-url --push origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
+      - name: Setup SSH deploy key
+        shell: pwsh
+        env:
+          EXCAVATOR_SSH_KEY: ${{ secrets.EXCAVATOR_SSH_KEY }}
+        run: |
+          $sshDir = Join-Path $env:USERPROFILE '.ssh'
+          New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
+          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath (Join-Path $sshDir 'id_ed25519') -Encoding ascii -NoNewline
+          # known_hosts に GitHub を登録
+          ssh-keyscan github.com | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Encoding ascii
+          git remote set-url origin "git@github.com:$($env:GITHUB_REPOSITORY).git"
       - name: Excavate
         shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOOP_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $ErrorActionPreference = 'Continue'
-          $originBranch = 'master'
+          $ErrorActionPreference = 'Stop'
           $scoopHome = scoop prefix scoop
           $bucketDir = Join-Path $env:GITHUB_WORKSPACE 'bucket'
 
@@ -65,46 +66,10 @@ jobs:
             $app = [System.IO.Path]::GetFileNameWithoutExtension($file)
             $json = Get-Content $file -Raw | ConvertFrom-Json
             $version = $json.version
-            $branch = "manifest/$app-$version"
 
-            # リモートブランチが既に存在する場合はスキップ
-            $remoteExists = git ls-remote --heads origin $branch
-            if ($remoteExists) {
-              Write-Host "Branch $branch already exists, skipping $app..."
-              git checkout -- $file
-              continue
-            }
-
-            Write-Host "Creating PR for $app $version..."
-
-            git checkout -b $branch
+            Write-Host "Pushing update: $app $version"
             git add $file
             git commit -m "${app}: Update to version ${version}"
-            git push origin $branch
-
-            if ($LASTEXITCODE -ne 0) {
-              Write-Host "Push failed for $branch, skipping..."
-              git checkout $originBranch
-              continue
-            }
-
-            $homepage = $json.homepage
-            $prBody = @"
-${app}: Update to version ${version}
-
-Hello lovely humans,
-a new version of [${app}](${homepage}) is available.
-
-| State       | Update |
-| :---------- | :----- |
-| New version | ${version} |
-"@
-
-            gh pr create `
-              --title "${app}: Update to version ${version}" `
-              --body $prBody `
-              --base $originBranch `
-              --head $branch
-
-            git checkout $originBranch
           }
+
+          git push origin master

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Scoop
@@ -28,7 +28,7 @@ jobs:
         run: |
           Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
           $installer = Join-Path $env:TEMP 'scoop-install.ps1'
-          Invoke-WebRequest 'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' -UseBasicParsing -OutFile $installer
+          Invoke-WebRequest 'https://raw.githubusercontent.com/ScoopInstaller/Install/b0ee913725139b816f9178163af0aecdba07a7ed/install.ps1' -UseBasicParsing -OutFile $installer
           & $installer
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:USERPROFILE 'scoop\shims')
       - name: Configure git

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -38,7 +38,10 @@ jobs:
         run: |
           $sshDir = Join-Path $env:USERPROFILE '.ssh'
           New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
-          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath (Join-Path $sshDir 'id_ed25519') -Encoding ascii -NoNewline
+          $keyPath = Join-Path $sshDir 'id_ed25519'
+          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath $keyPath -Encoding ascii -NoNewline
+          # Windows OpenSSH は ACL が緩いと鍵を拒否するため権限を絞る
+          icacls $keyPath /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
           # known_hosts に GitHub を登録
           ssh-keyscan github.com | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Encoding ascii
           git remote set-url origin "git@github.com:$($env:GITHUB_REPOSITORY).git"

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -1,12 +1,17 @@
 name: Excavator
 
-# See https://github.com/ScoopInstaller/Extras/blob/master/.github/workflows/excavator.yml
+# ScoopInstaller/GithubActions@main は -Push モード固定のため、
+# ブランチ保護ルール (PR 必須) に対応するためカスタムステップで -Request モードを使用する
 
 on:
   workflow_dispatch:
   schedule:
     # run every 4 hours
     - cron: "20 */4 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   excavate:
@@ -15,8 +20,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@main
-      - name: Excavate
-        uses: ScoopInstaller/GithubActions@main
+        with:
+          fetch-depth: 0
+      - name: Install Scoop
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+          $installer = Join-Path $env:TEMP 'scoop-install.ps1'
+          Invoke-WebRequest 'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' -UseBasicParsing -OutFile $installer
+          & $installer
+          Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:USERPROFILE 'scoop\shims')
+      - name: Install hub
+        shell: pwsh
+        run: scoop install hub
+      - name: Configure git
+        shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SKIP_UPDATED: "1"
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          $remUrl = "https://$($env:GITHUB_ACTOR):$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
+          git remote set-url --push origin $remUrl
+          git remote add upstream (git remote get-url origin)
+      - name: Excavate
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUB_VERBOSE: "1"
+        run: |
+          $scoopHome = scoop prefix scoop
+          & (Join-Path $scoopHome 'bin\auto-pr.ps1') `
+            -Upstream "$($env:GITHUB_REPOSITORY):master" `
+            -Dir (Join-Path $env:GITHUB_WORKSPACE 'bucket') `
+            -Request `
+            -SkipUpdated


### PR DESCRIPTION
## 変更概要

Excavator が deploy key を使って master へ直接 push するように変更する。

## 背景・原因

`ScoopInstaller/GithubActions@main` アクションは内部で master への直接 push を固定で行うが、ブランチ保護ルール (PR 必須・CI 必須) に違反するため CI エラーが発生していた。

代替として検討した `auto-pr.ps1 -Request` モードにも既知のバグ（[134 行目のクォート漏れ](https://github.com/ScoopInstaller/Scoop/blob/master/bin/auto-pr.ps1#L134)）があり使用不可だった。

PR 方式を一時的に実装したが、Excavator の更新はレビュー不要・直接 push で問題ないため、deploy key による master 直接 push に方針変更した。

## 変更内容

### `.github/workflows/excavator.yml`

- `ScoopInstaller/GithubActions@main` および `hub` CLI への依存を完全に排除
- **SSH deploy key** (`EXCAVATOR_SSH_KEY` シークレット) を使用して git push を認証
  - deploy key は ruleset の bypass actor に登録済み → ブランチ保護を迂回して master へ直接 push 可能
- `gh` CLI・PR 作成ロジックを削除し、ワークフローを大幅に簡略化
- `$ErrorActionPreference = 'Stop'` に変更してエラーを確実に検出
- アプリごとに個別コミットし、最後にまとめて `git push origin master`

## 動作フロー（修正後）

1. 4 時間ごとに Excavator が起動
2. Scoop の `checkver.ps1` で各マニフェストのバージョンを確認・更新
3. 更新があれば各アプリの変更を個別コミット
4. deploy key を使って master へ直接 push（ruleset バイパス）

## 関連する設定変更（このリポジトリ外）

- `EXCAVATOR_SSH_KEY` シークレット: 登録済み
- Ruleset bypass actors: deploy key (ID: 150225151) を追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
