### PR TITLE
fix: Excavator の SSH 認証失敗を修正

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.EXCAVATOR_SSH_KEY }}
       - name: Install Scoop
         shell: pwsh
         run: |
@@ -31,19 +32,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Setup SSH deploy key
-        shell: pwsh
-        env:
-          EXCAVATOR_SSH_KEY: ${{ secrets.EXCAVATOR_SSH_KEY }}
-        run: |
-          $sshDir = Join-Path $env:USERPROFILE '.ssh'
-          New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
-          $keyPath = Join-Path $sshDir 'id_ed25519'
-          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath $keyPath -Encoding ascii -NoNewline
-          # Windows OpenSSH は ACL が緩いと鍵を拒否するため権限を絞る
-          icacls $keyPath /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
-          # known_hosts に GitHub を登録
-          ssh-keyscan github.com | Out-File -FilePath (Join-Path $sshDir 'known_hosts') -Encoding ascii
+          # actions/checkout が ssh-key を使う場合、remote URL は HTTPS のままなので SSH URL に変更する
           git remote set-url origin "git@github.com:$($env:GITHUB_REPOSITORY).git"
       - name: Excavate
         shell: pwsh


### PR DESCRIPTION
## 概要

Excavator ワークフローで `git push` 時に SSH 認証が失敗する問題を修正します。

## 問題

`git@github.com: Permission denied (publickey)` エラーが発生し、バージョン更新のプッシュに失敗していました。

**原因**: 手動で `~/.ssh/id_ed25519` に SSH 鍵を書き込む方式では、Windows OpenSSH が Git に対して鍵を自動的に提供しない場合がある。`core.sshCommand` が設定されていないため、SSH エージェントなしでは鍵が認識されない。

## 修正内容

| 変更前 | 変更後 |
|---|---|
| `Setup SSH deploy key` ステップで手動に SSH 鍵を書き込み | `actions/checkout@v4` の `ssh-key` パラメータで SSH 鍵を渡す |
| SSH エージェントへの登録なし | `actions/checkout` が `core.sshCommand` を自動設定 |

- `actions/checkout@v4` の `ssh-key` パラメータを使用
  - checkout 時に SSH 鍵を渡すことで `core.sshCommand` が自動設定される
  - known_hosts も自動設定される
- `Setup SSH deploy key` ステップを廃止（不要になったため）
- `Configure git` ステップで remote URL を SSH URL に変更（checkout が HTTPS URL のままにするため）

## 使用するシークレット

- `secrets.EXCAVATOR_SSH_KEY`: 変更なし（引き続き同じシークレットを使用）