### PR TITLE
fix: SSH config ファイルによる確実な Deploy Key 認証

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.EXCAVATOR_SSH_KEY }}
       - name: Install Scoop
         shell: pwsh
         run: |
@@ -32,7 +31,44 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          # actions/checkout が ssh-key を使う場合、remote URL は HTTPS のままなので SSH URL に変更する
+      - name: Setup SSH for push
+        shell: pwsh
+        env:
+          EXCAVATOR_SSH_KEY: ${{ secrets.EXCAVATOR_SSH_KEY }}
+        run: |
+          $sshDir = Join-Path $env:USERPROFILE '.ssh'
+          New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
+
+          # 秘密鍵を書き込む
+          $keyPath = Join-Path $sshDir 'excavator_ed25519'
+          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath $keyPath -Encoding ascii -NoNewline
+
+          # Windows OpenSSH は ACL が緩いと鍵を拒否するため権限を絞る
+          icacls $keyPath /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
+
+          # known_hosts に GitHub を登録
+          $knownHostsPath = Join-Path $sshDir 'known_hosts'
+          ssh-keyscan -H github.com 2>$null | Out-File -FilePath $knownHostsPath -Encoding ascii
+
+          # SSH config を設定（GitHub 接続時に excavator_ed25519 を使用、BatchMode で認証失敗時に即座エラー）
+          @"
+Host github.com
+    IdentityFile $keyPath
+    StrictHostKeyChecking yes
+    UserKnownHostsFile $knownHostsPath
+    BatchMode yes
+"@ | Out-File -FilePath (Join-Path $sshDir 'config') -Encoding ascii
+
+          # SSH 接続テストで Deploy Key 認証を事前確認（exit 1 は GitHub の正常動作）
+          Write-Host 'Testing SSH connection to GitHub...'
+          $sshOutput = ssh -T git@github.com 2>&1
+          Write-Host $sshOutput
+          if ($sshOutput -notmatch 'successfully authenticated') {
+            Write-Error 'SSH authentication failed. Verify EXCAVATOR_SSH_KEY secret matches the registered deploy key.'
+            exit 1
+          }
+
+          # Deploy Key で Ruleset をバイパスするため SSH URL に変更
           git remote set-url origin "git@github.com:$($env:GITHUB_REPOSITORY).git"
       - name: Excavate
         shell: pwsh


### PR DESCRIPTION
## 概要

Excavator ワークフローの SSH 認証問題を根本から修正します。

## これまでの失敗経緯

| PR | 方式 | 結果 |
|---|---|---|
| #19 | 手動 `~/.ssh/id_ed25519` 書き込み | `Permission denied (publickey)` — `core.sshCommand` が未設定のため Git が鍵を認識しない |
| #20 | `actions/checkout@v4` の `ssh-key` パラメータ | `git fetch` が 6 時間ハング — `known_hosts` ファイルが作成されないため接続が詰まる |

## 原因

- Repository Ruleset により `GITHUB_TOKEN` では master への直接 push が不可（Deploy Key のみ bypass 可能）
- `actions/checkout@v4` の `ssh-key` パラメータを使うと `known_hosts` が設定されず、`git fetch` 段階でハングする

## 修正内容

- `actions/checkout@v4` は HTTPS で実行（ハングしない）
- `Setup SSH for push` ステップを追加:
  - 秘密鍵を `~/.ssh/excavator_ed25519` に書き込み、ACL を設定
  - `ssh-keyscan -H github.com` で `known_hosts` を明示的に登録
  - `~/.ssh/config` で `IdentityFile`・`StrictHostKeyChecking`・`BatchMode=yes` を設定
    - `BatchMode=yes` により認証失敗時に即座エラー（6 時間ハング防止）
    - `StrictHostKeyChecking=yes` + 明示的 `known_hosts` でホスト検証も確実
  - `ssh -T git@github.com` で push 前に Deploy Key 認証を事前確認
  - remote URL を SSH URL に変更（Deploy Key で Ruleset をバイパス）