### PR TITLE
fix: SSH config 書き込みをヒアドキュメントから Set-Content に変更

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -51,13 +51,12 @@ jobs:
           ssh-keyscan -H github.com 2>$null | Out-File -FilePath $knownHostsPath -Encoding ascii
 
           # SSH config を設定（GitHub 接続時に excavator_ed25519 を使用、BatchMode で認証失敗時に即座エラー）
-          @"
-Host github.com
-    IdentityFile $keyPath
-    StrictHostKeyChecking yes
-    UserKnownHostsFile $knownHostsPath
-    BatchMode yes
-"@ | Out-File -FilePath (Join-Path $sshDir 'config') -Encoding ascii
+          $sshConfigPath = Join-Path $sshDir 'config'
+          Set-Content -Path $sshConfigPath -Value "Host github.com" -Encoding ascii
+          Add-Content -Path $sshConfigPath -Value "    IdentityFile $keyPath" -Encoding ascii
+          Add-Content -Path $sshConfigPath -Value "    StrictHostKeyChecking yes" -Encoding ascii
+          Add-Content -Path $sshConfigPath -Value "    UserKnownHostsFile $knownHostsPath" -Encoding ascii
+          Add-Content -Path $sshConfigPath -Value "    BatchMode yes" -Encoding ascii
 
           # SSH 接続テストで Deploy Key 認証を事前確認（exit 1 は GitHub の正常動作）
           Write-Host 'Testing SSH connection to GitHub...'


### PR DESCRIPTION
## 概要

PowerShell のヒアドキュメント（`@"..."@`）が YAML パーサーに問題を引き起こし、`workflow file issue` エラーが発生していた問題を修正します。

## 変更内容

SSH config ファイルへの書き込みを、ヒアドキュメントから `Set-Content`/`Add-Content` による 1 行ずつの書き込みに変更。

機能的な変更はなく、生成される `~/.ssh/config` の内容は同一。