### PR TITLE
fix: 秘密鍵書き込み時の CRLF→LF 変換で OpenSSH invalid format を修正

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -39,9 +39,11 @@ jobs:
           $sshDir = Join-Path $env:USERPROFILE '.ssh'
           New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
 
-          # 秘密鍵を書き込む
+          # 秘密鍵を書き込む（CRLF を LF に変換し末尾改行を保証して OpenSSH が読める形式にする）
           $keyPath = Join-Path $sshDir 'excavator_ed25519'
-          $env:EXCAVATOR_SSH_KEY | Out-File -FilePath $keyPath -Encoding ascii -NoNewline
+          $keyContent = $env:EXCAVATOR_SSH_KEY -replace "`r`n", "`n" -replace "`r", "`n"
+          if (-not $keyContent.EndsWith("`n")) { $keyContent += "`n" }
+          [System.IO.File]::WriteAllBytes($keyPath, [System.Text.Encoding]::ASCII.GetBytes($keyContent))
 
           # Windows OpenSSH は ACL が緩いと鍵を拒否するため権限を絞る
           icacls $keyPath /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null


### PR DESCRIPTION
## 概要

`Setup SSH for push` ステップで `Load key: invalid format` エラーが発生していた問題を修正します。

## 原因

`Out-File -Encoding ascii` は Windows のデフォルト改行（CRLF）で書き込むため、OpenSSH が秘密鍵を読めない形式になっていた。

## 修正内容

`[System.IO.File]::WriteAllBytes()` でバイト列として直接書き込む方式に変更し、CRLF を LF に変換してから書き込む。